### PR TITLE
Return correct prescribed laravel versions

### DIFF
--- a/app/Console/Commands/SyncProjects.php
+++ b/app/Console/Commands/SyncProjects.php
@@ -170,6 +170,8 @@ class SyncProjects extends Command
                 'current_laravel_constraint' => $repository['constraint'],
                 'is_valid' => true,
             ]);
+
+            cache()->forget(sprintf(Project::DESIRED_VERSION_CACHE_KEY, $project->id));
         }
     }
 

--- a/app/Project.php
+++ b/app/Project.php
@@ -14,30 +14,34 @@ class Project extends Model
         'is_valid' => 'boolean',
     ];
 
+    public const DESIRED_VERSION_CACHE_KEY = 'project-desired-version--%s';
+
     public function getDesiredLaravelVersionAttribute()
     {
-        [$major, $minor] = explode('.', $this->current_laravel_version);
+        return cache()->remember(sprintf(self::DESIRED_VERSION_CACHE_KEY, $this->id), HOUR_IN_SECONDS, function () {
+            [$major, $minor] = explode('.', $this->current_laravel_version);
 
-        $query = LaravelVersion::query()->where('major', $major);
-        $sortColumn = 'minor';
+            $query = LaravelVersion::query()->where('major', $major);
+            $sortColumn = 'minor';
 
-        // If checking against the legacy version scheme then we're focusing
-        // on the highest patch version within the set minor version
-        if ((int) $major <= 5) {
-            $query = $query->where('minor', $minor);
-            $sortColumn = 'patch';
-        }
+            // If checking against the legacy version scheme then we're focusing
+            // on the highest patch version within the set minor version
+            if ((int) $major <= 5) {
+                $query = $query->where('minor', $minor);
+                $sortColumn = 'patch';
+            }
 
-        return (string) $query->get()
-            ->tap(function ($collection) {
-                if ($collection->count() === 0) {
-                    throw (new ModelNotFoundException)->setModel(Project::class);
-                }
-            })
-            ->sortByDesc(function ($version) use ($sortColumn) {
-                return (int) $version->$sortColumn;
-            })
-            ->first();
+            return (string) $query->get()
+                ->tap(function ($collection) {
+                    if ($collection->count() === 0) {
+                        throw (new ModelNotFoundException)->setModel(Project::class);
+                    }
+                })
+                ->sortByDesc(function ($version) use ($sortColumn) {
+                    return (int) $version->$sortColumn;
+                })
+                ->first();
+        });
     }
 
     public function getGithubUrlAttribute()

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -6,17 +6,13 @@ use Faker\Generator as Faker;
 
 $factory->define(Project::class, function (Faker $faker) {
 
-    $version = factory(LaravelVersion::class)->create([
-        'major' => '7',
-        'minor' => '10',
-        'patch' => '3',
-    ]);
-
     return [
         'name' => $faker->sentence,
         'vendor' => 'tighten',
         'package' => $faker->slug,
-        'current_laravel_version' => (string) $version,
+        'current_laravel_version' => function () {
+            return factory(LaravelVersion::class)->create()->__toString();
+        },
         'current_laravel_constraint' => '^7.0',
         'is_valid' => true,
         'ignored' => false,

--- a/tests/Feature/DesiredProjectVersionTest.php
+++ b/tests/Feature/DesiredProjectVersionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\LaravelVersion;
+use App\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DesiredProjectVersionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function returns_desired_version_for_legacy_versioning_scheme()
+    {
+        // given there is a project at 5.3.30
+        $project = factory(Project::class)->create([
+            'current_laravel_version' => '5.3.30',
+            'current_laravel_constraint' => '5.3.*',
+        ]);
+
+        // and there is a laravel version for 5.3.35
+        factory(LaravelVersion::class)->create([
+            'major' => '5',
+            'minor' => '3',
+            'patch' => '35',
+        ]);
+
+        // and the latest laravel version is 5.4.35
+        factory(LaravelVersion::class)->create([
+            'major' => '5',
+            'minor' => '4',
+            'patch' => '35',
+        ]);
+
+        // then the project's desired version should stick to the 5.3 branch
+        $this->assertEquals('5.3.35', $project->desired_laravel_version);
+    }
+
+    /** @test */
+    function returns_desired_version_for_modern_versioning_scheme()
+    {
+        // given there is a project at 6.14
+        $project = factory(Project::class)->create([
+            'current_laravel_version' => '6.14.0',
+            'current_laravel_constraint' => '^6.0',
+        ]);
+
+        // and the latest laravel version is 6.18.0
+        factory(LaravelVersion::class)->create([
+            'major' => '6',
+            'minor' => '18',
+            'patch' => '0',
+        ]);
+
+        // then the project's desired version should be 6.18.0
+        $this->assertEquals('6.18.0', $project->desired_laravel_version);
+    }
+
+    /** @test */
+    function returns_the_latest_version_for_the_legacy_versioning_scheme()
+    {
+        // given a version 5.3.10 exists
+        factory(LaravelVersion::class)->create([
+            'major' => '5',
+            'minor' => '3',
+            'patch' => '10',
+        ]);
+
+        // and a version 5.3.12 exists
+        factory(LaravelVersion::class)->create([
+            'major' => '5',
+            'minor' => '3',
+            'patch' => '12',
+        ]);
+
+        // when a laravel 5.3 project exists
+        $project = factory(Project::class)->create([
+            'current_laravel_version' => '5.3.1',
+            'current_laravel_constraint' => '^5.3.*',
+        ]);
+
+        // then the desired version should be 5.3.12
+        $this->assertEquals('5.3.12', $project->desired_laravel_version);
+    }
+
+    /** @test */
+    function returns_the_latest_version_for_the_modern_versioning_scheme()
+    {
+        // given a version 7.18.0 exists
+        factory(LaravelVersion::class)->create([
+            'major' => '7',
+            'minor' => '18',
+            'patch' => '0',
+        ]);
+
+        // and a version 7.19.0 exists
+        factory(LaravelVersion::class)->create([
+            'major' => '7',
+            'minor' => '19',
+            'patch' => '0',
+        ]);
+
+        // when a laravel 7 project exists
+        $project = factory(Project::class)->create([
+            'current_laravel_version' => '7.10.0',
+            'current_laravel_constraint' => '^7.0',
+        ]);
+
+        // then the desired version should be 7.19.0
+        $this->assertEquals('7.19.0', $project->desired_laravel_version);
+    }
+}


### PR DESCRIPTION
This PR returns the correct value for a project's desired/prescribed version depending on the project's Laravel version. For example, projects that are on the `4.x` and `5.x` branches should check against the latest patch release while projects on `6.x` and above should check the minor release.

In other words, a project that is at `5.5.49` should be considered current even though there is a `5.6.40` release available while a project that is at `7.19.1` should be considered behind since there is a `7.22.4` release available.

For reference, the semver versioning scheme is `MAJOR.MINOR.PATCH`.

![image](https://user-images.githubusercontent.com/1141514/88708506-95979f80-d0c8-11ea-8722-dc9cd4c65f11.png)
